### PR TITLE
Fix issuing notifications for a single light change

### DIFF
--- a/spec/stoplight/default_spec.rb
+++ b/spec/stoplight/default_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Stoplight::Default do
 
   describe '::THRESHOLD' do
     it 'is an integer' do
-      expect(Stoplight::Default::THRESHOLD).to be_a(Fixnum)
+      expect(Stoplight::Default::THRESHOLD).to be_a(Integer)
     end
   end
 end


### PR DESCRIPTION
Previously, if a light changed to red before a request that failed returned, it would also 'set' the light to red and trigger another notification. This fixes this by only triggering the notification if the light was still green before handling the error.